### PR TITLE
test: add endpoint login tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 dist
+mongo_data

--- a/tests/routes/auth.login.test.js
+++ b/tests/routes/auth.login.test.js
@@ -1,0 +1,31 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../../src/routes/auth.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1', router);
+
+describe('POST /api/v1/login', () => {
+  
+  test('should return 400 status code', async () => {
+    const response = await request(app)
+      .post('/api/v1/login')
+      .send({ email: 'test@test.com', password: '123456' });
+
+    expect(response.status).toBe(400);
+  });
+
+  test('should return correct error message', async () => {
+    const response = await request(app).post('/api/v1/login');
+
+    expect(response.body.error).toBe('Traditional login disabled. Please use Google OAuth.');
+  });
+
+  test('should return oauth_url field', async () => {
+    const response = await request(app).post('/api/v1/login');
+
+    expect(response.body).toHaveProperty('oauth_url', '/api/v1/auth/google');
+  });
+
+});


### PR DESCRIPTION
Adds a test suite for the /login endpoint, ensuring that the expected behavior—an error return for traditional login—is properly validated.

- Three automated tests were created covering:

- Verification of the 400 status code

- Validation of the returned error message

Ensure that the endpoint correctly provides the OAuth URL (/api/v1/auth/google)

These tests ensure that future changes to the authentication flow do not break the behavior of this legacy endpoint, maintaining the integrity and predictability of the API.

(i added mongo_data to the .gitignore file.)

issue: #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated tests covering login behavior: ensures traditional login is disabled, returns a clear guidance message to use Google OAuth, and includes the OAuth URL in responses.
* **Chores**
  * Updated repository ignore rules to exclude local database dump/storage directory from version control.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->